### PR TITLE
Support python 3.11 and 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Version history
 
-We follow Semantic Versions since the `0.1.0` release.
+We follow [Semantic Versioning](https://semver.org/) since the `0.1.0` release.
 
+## Version 1.3.1
+
+### Features
+
+- Explicitly support `python3.11` and `python3.12`
 
 ## Version 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ pip install jinja2-git
 ## Reasoning
 
 This plugin is used to render commit hash in `jinja2` templates. We are
-using it to render our template version in `cookicutter`:
+using it to render our template version in `cookiecutter`:
 
 - [wemake-django-template](https://github.com/wemake-services/wemake-django-template)
 - [wemake-vue-template](https://github.com/wemake-services/wemake-vue-template)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jinja2-git"
-version = "1.3.0"
+version = "1.3.1"
 description = "Jinja2 extension to handle git-specific things"
 
 license = "MIT"
@@ -29,6 +29,14 @@ classifiers=[
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Python Modules",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
On pypi, we don't explicitly support this:

https://pypi.org/project/jinja2-git/

![image](https://github.com/wemake-services/jinja2-git/assets/5570380/55717df1-3c12-4e39-b5a6-b59e4ea943b0)

This PR fixes that.

Ping @sobolevn 